### PR TITLE
Permit format to be unset

### DIFF
--- a/src/cloudinary-image.service.ts
+++ b/src/cloudinary-image.service.ts
@@ -8,14 +8,22 @@ const CLOUDINARY_URL: string = 'https://res.cloudinary.com/';
 export class CloudinaryImageService {
 
     getImageUrl(publicId: string, cloudName: string, resourceType: string, type: string, transforms: CloudinaryTransforms): string {
-        return  CLOUDINARY_URL +
-            cloudName + '/' +
-            resourceType + '/' +
-            type + '/' +
-            transforms.toUrlSegment() +
-            publicId + '.' + (transforms.format || 'jpg');
 
+    let constuctedURL = CLOUDINARY_URL +
+      cloudName + '/' +
+      resourceType + '/' +
+      type + '/' +
+      transforms.toUrlSegment() + publicId;
+
+    // Permit format to be unset
+    // If unset, Cloudinary returns the image in the format that it was uploaded in
+    if (transforms.format) {
+      constuctedURL += "." + transforms.format;
     }
+
+    return constuctedURL;
+
+  }
 }
 
 

--- a/src/cloudinary-image.service.ts
+++ b/src/cloudinary-image.service.ts
@@ -9,7 +9,7 @@ export class CloudinaryImageService {
 
     getImageUrl(publicId: string, cloudName: string, resourceType: string, type: string, transforms: CloudinaryTransforms): string {
 
-    let constuctedURL = CLOUDINARY_URL +
+    let constuctedURL : string = CLOUDINARY_URL +
       cloudName + '/' +
       resourceType + '/' +
       type + '/' +
@@ -18,7 +18,7 @@ export class CloudinaryImageService {
     // Permit format to be unset
     // If unset, Cloudinary returns the image in the format that it was uploaded in
     if (transforms.format) {
-      constuctedURL += "." + transforms.format;
+      constuctedURL += '.' + transforms.format;
     }
 
     return constuctedURL;

--- a/test/cloudinary-image.component.spec.ts
+++ b/test/cloudinary-image.component.spec.ts
@@ -49,7 +49,7 @@ describe('CloudinaryImage component', () => {
     clImageComponent.ngOnChanges(null);
     fixture.detectChanges();
 
-    let expectedImageUrl: string = 'https://res.cloudinary.com/ekito/image/upload/testPublicId.jpg';
+    let expectedImageUrl: string = 'https://res.cloudinary.com/ekito/image/upload/testPublicId';
     expect(clImageComponent.imageUrl).to.equal(expectedImageUrl);
     expect(fixture.nativeElement.innerHTML.trim()).to.contain('img');
     expect(fixture.nativeElement.innerHTML.trim()).to.contain('src="' + expectedImageUrl + '"');
@@ -65,7 +65,7 @@ describe('CloudinaryImage component', () => {
     clImageComponent.ngOnChanges(null);
     fixture.detectChanges();
 
-    let expectedImageUrl: string = 'https://res.cloudinary.com/ekito/image/upload/h_100,w_150/testPublicId.jpg';
+    let expectedImageUrl: string = 'https://res.cloudinary.com/ekito/image/upload/h_100,w_150/testPublicId';
     expect(clImageComponent.imageUrl).to.equal(expectedImageUrl);
     expect(fixture.nativeElement.innerHTML.trim()).to.contain('img');
     expect(fixture.nativeElement.innerHTML.trim()).to.contain('src="' + expectedImageUrl + '"');
@@ -81,7 +81,7 @@ describe('CloudinaryImage component', () => {
     clImageComponent.ngOnChanges(null);
     fixture.detectChanges();
 
-    let expectedImageUrl: string = 'https://res.cloudinary.com/ekito/image/upload/testPublicId.jpg';
+    let expectedImageUrl: string = 'https://res.cloudinary.com/ekito/image/upload/testPublicId';
     expect(clImageComponent.imageUrl).to.equal(expectedImageUrl);
     expect(fixture.nativeElement.innerHTML.trim()).to.contain('img');
     expect(fixture.nativeElement.innerHTML.trim()).to.contain('src="' + expectedImageUrl + '"');


### PR DESCRIPTION
When format is not provided (unset), no . (dot) and no jpg should be added to the image URL. In this situation Cloudinary returns the image in the format it was uploaded in

i.e. if the user had uploaded as JPG, it will return as JPG, if they had uploaded as PNG, it would return as PNG. 

Includes updates to tests which were also not matching the Cloudinary specification